### PR TITLE
support Apache2.4

### DIFF
--- a/mod_dosdetector.c
+++ b/mod_dosdetector.c
@@ -65,6 +65,10 @@
 #define DEFAULT_BAN_PERIOD 300
 #define DEFAULT_TABLE_SIZE 100
 
+#if (AP_SERVER_MINORVERSION_NUMBER > 2)
+static const char *DefaultContentType = "text/plain";
+#endif
+
 module AP_MODULE_DECLARE_DATA dosdetector_module;
 
 struct s_client {
@@ -260,7 +264,13 @@ static int dosdetector_handler(request_rec *r)
     int i;
 
     content_type = ap_sub_req_lookup_uri(r->uri, r, NULL)->content_type;
-    if (!content_type) content_type = ap_default_type(r);
+    if (!content_type) {
+#if (AP_SERVER_MINORVERSION_NUMBER > 2)
+        content_type = DefaultContentType;
+#else
+        content_type = ap_default_type(r);
+#endif
+    }
 
 	if (cfg->forwarded){
 		if ((address_tmp = apr_table_get(r->headers_in, "X-Forwarded-For")) != NULL){
@@ -271,7 +281,7 @@ static int dosdetector_handler(request_rec *r)
 		}
 	}
 	if (address == NULL)
-		address = r->connection->remote_ip;
+		address = r->connection->client_ip;
 
     ap_regmatch_t regmatch[AP_MAX_REG_MATCH];
     ap_regex_t **contenttype_regexp = (ap_regex_t **) cfg->contenttype_regexp->elts;
@@ -285,7 +295,7 @@ static int dosdetector_handler(request_rec *r)
 
 	struct in_addr addr;
 	if(!cfg->forwarded)
-		addr = r->connection->remote_addr->sa.sin.sin_addr;
+		addr = r->connection->client_addr->sa.sin.sin_addr;
 	if(cfg->forwarded || addr.s_addr == 0){
 		if (inet_aton(address, &addr) == 0) {
 			TRACELOG("dosdetector: '%s' is not  a valid IP addresss", address);

--- a/mod_dosdetector.c
+++ b/mod_dosdetector.c
@@ -280,8 +280,13 @@ static int dosdetector_handler(request_rec *r)
 			address = apr_pstrndup(r->pool, address_tmp, i - address_tmp);
 		}
 	}
-	if (address == NULL)
+	if (address == NULL) {
+#if (AP_SERVER_MINORVERSION_NUMBER > 2)
 		address = r->connection->client_ip;
+#else
+		address = r->connection->remote_ip;
+#endif
+    }
 
     ap_regmatch_t regmatch[AP_MAX_REG_MATCH];
     ap_regex_t **contenttype_regexp = (ap_regex_t **) cfg->contenttype_regexp->elts;
@@ -294,8 +299,13 @@ static int dosdetector_handler(request_rec *r)
 	DEBUGLOG("dosdetector: processing content-type: %s", content_type);
 
 	struct in_addr addr;
-	if(!cfg->forwarded)
+	if(!cfg->forwarded) {
+#if (AP_SERVER_MINORVERSION_NUMBER > 2)
 		addr = r->connection->client_addr->sa.sin.sin_addr;
+#else
+		addr = r->connection->remote_addr->sa.sin.sin_addr;
+#endif
+    }
 	if(cfg->forwarded || addr.s_addr == 0){
 		if (inet_aton(address, &addr) == 0) {
 			TRACELOG("dosdetector: '%s' is not  a valid IP addresss", address);


### PR DESCRIPTION
In Apache2.4, Following changes make building mod_dosdetector failed.
- ap_default_type is removed
- r->connection->remote_(ip|addr) is renamed to r->connection->client_(ip|addr)

``` zsh
$ make
/usr/local/apache2/bin/apxs -c    mod_dosdetector.c
/usr/share/apr-1.0/build/libtool --silent --mode=compile x86_64-linux-gnu-gcc -std=gnu99 -prefer-pic   -D_REENTRANT -D_GNU_SOURCE -pthread -I/usr/local/apache2/include  -I/usr/include/apr-1.0   -I/usr/include/apr-1.0 -I/usr/include  -c -o mod_dosdetector.lo mod_dosdetector.c && touch mod_dosdetector.slo
mod_dosdetector.c: In function ‘create_shm’:
mod_dosdetector.c:144:5: warning: format ‘%d’ expects argument of type ‘int’, but argument 9 has type ‘size_t’ [-Wformat]
mod_dosdetector.c: In function ‘dosdetector_handler’:
mod_dosdetector.c:263:5: warning: implicit declaration of function ‘ap_default_type’ [-Wimplicit-function-declaration]
mod_dosdetector.c:263:37: warning: assignment makes pointer from integer without a cast [enabled by default]
mod_dosdetector.c:274:26: error: ‘conn_rec’ has no member named ‘remote_ip’
mod_dosdetector.c:288:23: error: ‘conn_rec’ has no member named ‘remote_addr’
$
```
# Note

| My Environment | Version |
| --- | --- |
| Compiler | GCC 4.7.2 |
| OS | Linux Mint 14(nadia) 64bit kernel-release is 3.5.0-27-generic |
| Apache | 2.4.4 |
